### PR TITLE
Update frankjpeg.py

### DIFF
--- a/commands/frankjpeg.py
+++ b/commands/frankjpeg.py
@@ -1,5 +1,6 @@
 import bot
 import discord
+import os
 
 
 def import_command():
@@ -7,30 +8,38 @@ def import_command():
     # Create Command Group
     frank_jpeg_commands = discord.app_commands.Group(
         name='frankjpeg',
-        description='Choose a specific Frank Jpeg'
+        description='Choose a specific Frank jpeg'
     )
 
     # Add Command Group to Tree
     bot.tree.add_command(frank_jpeg_commands)
 
-    # Main Command
+    # Number Command
     @frank_jpeg_commands.command(
-        name="-",
-        description="Choose a specific Frank Jpeg"
+        name="num",
+        description="Choose a Frank jpeg by number"
     )
-    async def send_frank_jpeg(interaction: discord.Interaction,
-                              option: int):
-        await interaction.response.send_message(file=discord.File(bot.assets[option]))
+    async def send_frank_jpeg_num(interaction: discord.Interaction, option: int):
+        await interaction.response.send_message(file = discord.File(bot.assets[option]))
+
+    # Name Command
+    @frank_jpeg_commands.command(
+        name="name",
+        description="Choose a Frank jpeg by name, including the file extension"
+    )
+    async def send_frank_jpeg_name(interaction: discord.Interaction, option: str):
+        # Get just the file names
+        jpegNames = [os.path.basename(asset).casefold() for asset in bot.assets]
+        jpegIndex = jpegNames.index(option.casefold())
+        await interaction.response.send_message(file = discord.File(bot.assets[jpegIndex]))
 
     # List Sub-Command
     @frank_jpeg_commands.command(
         name='list',
-        description='List applicable Jpegs to send'
+        description='List Frank jpegs'
     )
     async def list_frank_jpegs(interaction: discord.Interaction):
         message = 'Frank jpegs:'
-        asset_id = 0
-        for jpegName in bot.assets:
-            message += f'\n*{asset_id}*: **__{jpegName[7:]}__**'
-            asset_id += 1
+        for asset_id, jpegName in enumerate(bot.assets):
+            message += f'\n*{asset_id}*: **{os.path.basename(jpegName)}**'
         await interaction.response.send_message(message)


### PR DESCRIPTION
Renames sub-command "-" to "num".

Adds new sub-command "name" which chooses an image by name.

Clarifies usage in command descriptions.

Cleanup on list sub-command:
- Use `enumerate()` instead of a manual index counter.
- Use `os.path.basename()` instead of a slice to remove path to file.
- Remove underline from file name to avoid hiding underscores.